### PR TITLE
Generalize interface to support other providers

### DIFF
--- a/cyqldog.example.yml
+++ b/cyqldog.example.yml
@@ -1,4 +1,4 @@
-db:
+data_source:
   driver: postgres
   options:
     host: {{ .DB_HOST }}

--- a/cyqldog/checker.go
+++ b/cyqldog/checker.go
@@ -1,7 +1,6 @@
 package cyqldog
 
 import (
-	"database/sql"
 	"log"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -10,7 +9,7 @@ import (
 
 // Checker is a worker that executes SQLs and sends metrics.
 type Checker struct {
-	db     *sql.DB
+	ds     DataSource
 	statsd *statsd.Client
 }
 
@@ -27,15 +26,15 @@ type result struct {
 }
 
 // newChecker returns an instance of Checker.
-func newChecker(db *sql.DB, statsd *statsd.Client) *Checker {
+func newChecker(ds DataSource, statsd *statsd.Client) *Checker {
 	return &Checker{
-		db:     db,
+		ds:     ds,
 		statsd: statsd,
 	}
 }
 
 // run processes the monitoring task queue enqueued by the Scheduler.
-func (m *Checker) run(q chan Rule) {
+func (c *Checker) run(q chan Rule) {
 	log.Printf("checker: start")
 
 	for {
@@ -43,7 +42,7 @@ func (m *Checker) run(q chan Rule) {
 		case rule := <-q:
 			// dequeue the task and check.
 			log.Printf("checker: check: %s", rule.Name)
-			err := m.check(rule)
+			err := c.check(rule)
 			if err != nil {
 				// Currently, there is no way to notify errors.
 				// So we simply exit the program for the time being.
@@ -54,67 +53,22 @@ func (m *Checker) run(q chan Rule) {
 }
 
 // check gets the metrics and sends them.
-func (m *Checker) check(rule Rule) error {
-	result, err := m.get(rule)
+func (c *Checker) check(rule Rule) error {
+	result, err := c.ds.Get(rule)
 	if err != nil {
 		return err
 	}
-	return m.put(result)
-}
-
-// get queries the database to generate metrics.
-func (m *Checker) get(rule Rule) (result, error) {
-	r := result{}
-
-	// Execute the SQL.
-	log.Printf("checker: query: %s", rule.Query)
-	rows, err := m.db.Query(rule.Query)
-	if err != nil {
-		return r, errors.Wrapf(err, "failed to query: %s", rule.Query)
-	}
-	defer rows.Close()
-
-	// Get columns to map metric values and tags.
-	cols, err := rows.Columns()
-	if err != nil {
-		return r, errors.Wrapf(err, "failed to get column names: %s", rule.Query)
-	}
-
-	// For each rows.
-	for rows.Next() {
-		// At this point, the type of each column is unknown.
-		// So we temporarily store values in a slice of interface.
-		row := make([]interface{}, len(cols))
-		rowPtr := make([]interface{}, len(cols))
-		for i := range row {
-			// Scan requires a slice of pointers.
-			rowPtr[i] = &row[i]
-		}
-		err := rows.Scan(rowPtr...)
-		if err != nil {
-			return r, errors.Wrapf(err, "failed to scan value: %s", rule.Query)
-		}
-
-		// Convert the row to metrics.
-		metrics, err := rule.buildMetrics(row, cols)
-		if err != nil {
-			return r, err
-		}
-
-		// Add metrics to the result.
-		r.metrics = append(r.metrics, metrics...)
-	}
-	return r, err
+	return c.put(result)
 }
 
 // put sends metrics to the dogstatsd.
-func (m *Checker) put(r result) error {
+func (c *Checker) put(r result) error {
 	// For each metric.
 	for _, metric := range r.metrics {
 		log.Printf("checker: put: %s(%s) = %v\n", metric.name, metric.tags, metric.value)
 
 		// Send a metic to the dogstatsd.
-		err := m.statsd.Gauge(metric.name, metric.value, metric.tags, 1)
+		err := c.statsd.Gauge(metric.name, metric.value, metric.tags, 1)
 		if err != nil {
 			return errors.Wrapf(err, "failed to gauge statsd for name = %s, value = %v, tags = %v", metric.name, metric.value, metric.tags)
 		}

--- a/cyqldog/checker.go
+++ b/cyqldog/checker.go
@@ -58,13 +58,19 @@ func (c *Checker) check(rule Rule) error {
 	if err != nil {
 		return err
 	}
-	return c.put(result)
+	return c.Put(result, rule)
 }
 
-// put sends metrics to the dogstatsd.
-func (c *Checker) put(r result) error {
+// Put sends metrics to the dogstatsd.
+func (c *Checker) Put(qr QueryResult, rule Rule) error {
+	// convert to the query result to metrics.
+	metrics, err := buildMetricsForQueryResult(qr, rule)
+	if err != nil {
+		return err
+	}
+
 	// For each metric.
-	for _, metric := range r.metrics {
+	for _, metric := range metrics {
 		log.Printf("checker: put: %s(%s) = %v\n", metric.name, metric.tags, metric.value)
 
 		// Send a metic to the dogstatsd.

--- a/cyqldog/config.go
+++ b/cyqldog/config.go
@@ -14,7 +14,7 @@ import (
 // Config represents the structure of the configuration file.
 type Config struct {
 	// Db is a configuration of the database to connect.
-	Db DataSourceConfig `yaml:"data_source"`
+	DB DataSourceConfig `yaml:"data_source"`
 	// Statsd is a configuration of the dogstatsd to connect.
 	Statd Dogstatsd `yaml:"dogstatsd"`
 	// Rules are a list of rules to monitor

--- a/cyqldog/config.go
+++ b/cyqldog/config.go
@@ -13,10 +13,10 @@ import (
 
 // Config represents the structure of the configuration file.
 type Config struct {
-	// Db is a configuration of the database to connect.
+	// DB is a configuration of the database to connect.
 	DB DataSourceConfig `yaml:"data_source"`
-	// Statsd is a configuration of the dogstatsd to connect.
-	Statd Dogstatsd `yaml:"dogstatsd"`
+	// Notifiers are configurations of output plugins.
+	Notifiers NotifiersConfig `yaml:"notifiers"`
 	// Rules are a list of rules to monitor
 	Rules []Rule `yaml:"rules"`
 }

--- a/cyqldog/config.go
+++ b/cyqldog/config.go
@@ -14,7 +14,7 @@ import (
 // Config represents the structure of the configuration file.
 type Config struct {
 	// Db is a configuration of the database to connect.
-	Db DataSource `yaml:"db"`
+	Db DataSourceConfig `yaml:"data_source"`
 	// Statsd is a configuration of the dogstatsd to connect.
 	Statd Dogstatsd `yaml:"dogstatsd"`
 	// Rules are a list of rules to monitor

--- a/cyqldog/data_source.go
+++ b/cyqldog/data_source.go
@@ -8,8 +8,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// DataSource is a configuration of the database to connect.
-type DataSource struct {
+// DataSourceConfig is a configuration of the database to connect.
+type DataSourceConfig struct {
 	// Driver is type of the database to connect.
 	// Currently suppoted databases are as follows:
 	//  - postgres
@@ -26,7 +26,7 @@ type DataSourceOptions map[string]string
 
 // newDB returns an instance of sql.DB.
 // This function returns a error if the connection test fails.
-func newDB(s DataSource) (*sql.DB, error) {
+func newDB(s DataSourceConfig) (*sql.DB, error) {
 
 	// Join the options into a string of data source name.
 	dataSourceName, err := s.getDataSourceName()
@@ -51,7 +51,7 @@ func newDB(s DataSource) (*sql.DB, error) {
 }
 
 // getDataSourceName returns a data source name to use for sql.Open.
-func (s *DataSource) getDataSourceName() (string, error) {
+func (s *DataSourceConfig) getDataSourceName() (string, error) {
 	// Check database driver
 	switch s.Driver {
 	case "postgres":
@@ -63,7 +63,7 @@ func (s *DataSource) getDataSourceName() (string, error) {
 	}
 }
 
-func (s *DataSource) getDataSourceNamePostgres() (string, error) {
+func (s *DataSourceConfig) getDataSourceNamePostgres() (string, error) {
 	opts := make([]string, len(s.Options))
 	for k, v := range s.Options {
 		o := k + "=" + v
@@ -73,7 +73,7 @@ func (s *DataSource) getDataSourceNamePostgres() (string, error) {
 	return strings.Join(opts[:], " "), nil
 }
 
-func (s *DataSource) getDataSourceNameMySQL() (string, error) {
+func (s *DataSourceConfig) getDataSourceNameMySQL() (string, error) {
 	o := s.Options
 
 	// render DSN format

--- a/cyqldog/data_source.go
+++ b/cyqldog/data_source.go
@@ -9,8 +9,16 @@ import (
 
 // DataSource is an interface from which to get metrics.
 type DataSource interface {
-	Get(rule Rule) (result, error)
+	Get(rule Rule) (QueryResult, error)
 	Close() error
+}
+
+// Record is a map of column / value pairs representing one row.
+type Record map[string]string
+
+// QueryResult has multiple records.
+type QueryResult struct {
+	Records []Record
 }
 
 // DataSourceConfig is a configuration of the database to connect.

--- a/cyqldog/data_source.go
+++ b/cyqldog/data_source.go
@@ -1,12 +1,17 @@
 package cyqldog
 
 import (
-	"database/sql"
 	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
 )
+
+// DataSource is an interface from which to get metrics.
+type DataSource interface {
+	Get(rule Rule) (result, error)
+	Close() error
+}
 
 // DataSourceConfig is a configuration of the database to connect.
 type DataSourceConfig struct {
@@ -23,32 +28,6 @@ type DataSourceConfig struct {
 
 // DataSourceOptions is a map of options to connect.
 type DataSourceOptions map[string]string
-
-// newDB returns an instance of sql.DB.
-// This function returns a error if the connection test fails.
-func newDB(s DataSourceConfig) (*sql.DB, error) {
-
-	// Join the options into a string of data source name.
-	dataSourceName, err := s.getDataSourceName()
-	if err != nil {
-		return nil, err
-	}
-
-	// Open the database.
-	// Note that network connection is not established at this time.
-	db, err := sql.Open(s.Driver, dataSourceName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open database")
-	}
-
-	// Connect to the database and verify its connection.
-	if err = db.Ping(); err != nil {
-		db.Close()
-
-		return nil, errors.Wrapf(err, "failed to connect database")
-	}
-	return db, nil
-}
 
 // getDataSourceName returns a data source name to use for sql.Open.
 func (s *DataSourceConfig) getDataSourceName() (string, error) {

--- a/cyqldog/data_source.go
+++ b/cyqldog/data_source.go
@@ -7,7 +7,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// DataSource is an interface from which to get metrics.
+// DataSource is an interface which get metrics from.
 type DataSource interface {
 	Get(rule Rule) (QueryResult, error)
 	Close() error

--- a/cyqldog/db.go
+++ b/cyqldog/db.go
@@ -15,17 +15,17 @@ type DB struct {
 
 // newDB returns an instance of DataSource interface.
 // This function returns a error if the connection test fails.
-func newDB(s DataSourceConfig) (DataSource, error) {
+func newDB(c DataSourceConfig) (DataSource, error) {
 
 	// Join the options into a string of data source name.
-	dataSourceName, err := s.getDataSourceName()
+	dataSourceName, err := c.getDataSourceName()
 	if err != nil {
 		return nil, err
 	}
 
 	// Open the database.
 	// Note that network connection is not established at this time.
-	db, err := sql.Open(s.Driver, dataSourceName)
+	db, err := sql.Open(c.Driver, dataSourceName)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open database")
 	}

--- a/cyqldog/db.go
+++ b/cyqldog/db.go
@@ -1,0 +1,90 @@
+package cyqldog
+
+import (
+	"database/sql"
+	"log"
+
+	"github.com/pkg/errors"
+)
+
+// DB is an implementation of DataSource.
+type DB struct {
+	db *sql.DB
+}
+
+// newDB returns an instance of DataSource interface.
+// This function returns a error if the connection test fails.
+func newDB(s DataSourceConfig) (DataSource, error) {
+
+	// Join the options into a string of data source name.
+	dataSourceName, err := s.getDataSourceName()
+	if err != nil {
+		return nil, err
+	}
+
+	// Open the database.
+	// Note that network connection is not established at this time.
+	db, err := sql.Open(s.Driver, dataSourceName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to open database")
+	}
+
+	// Connect to the database and verify its connection.
+	if err = db.Ping(); err != nil {
+		db.Close()
+
+		return nil, errors.Wrapf(err, "failed to connect database")
+	}
+
+	return &DB{db: db}, nil
+}
+
+// Get queries the database to generate metrics.
+func (d *DB) Get(rule Rule) (result, error) {
+	r := result{}
+
+	// Execute the SQL.
+	log.Printf("db: query: %s", rule.Query)
+	rows, err := d.db.Query(rule.Query)
+	if err != nil {
+		return r, errors.Wrapf(err, "failed to query: %s", rule.Query)
+	}
+	defer rows.Close()
+
+	// Get columns to map metric values and tags.
+	cols, err := rows.Columns()
+	if err != nil {
+		return r, errors.Wrapf(err, "failed to get column names: %s", rule.Query)
+	}
+
+	// For each rows.
+	for rows.Next() {
+		// At this point, the type of each column is unknown.
+		// So we temporarily store values in a slice of interface.
+		row := make([]interface{}, len(cols))
+		rowPtr := make([]interface{}, len(cols))
+		for i := range row {
+			// Scan requires a slice of pointers.
+			rowPtr[i] = &row[i]
+		}
+		err := rows.Scan(rowPtr...)
+		if err != nil {
+			return r, errors.Wrapf(err, "failed to scan value: %s", rule.Query)
+		}
+
+		// Convert the row to metrics.
+		metrics, err := rule.buildMetrics(row, cols)
+		if err != nil {
+			return r, err
+		}
+
+		// Add metrics to the result.
+		r.metrics = append(r.metrics, metrics...)
+	}
+	return r, err
+}
+
+// Close closes the database connection.
+func (d *DB) Close() error {
+	return d.db.Close()
+}

--- a/cyqldog/dogstatd.go
+++ b/cyqldog/dogstatd.go
@@ -2,6 +2,7 @@ package cyqldog
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/pkg/errors"
@@ -30,4 +31,57 @@ func newStatsd(d Dogstatsd) (*statsd.Client, error) {
 	c.Namespace = d.Namespace + "."
 	c.Tags = append(c.Tags, d.Tags...)
 	return c, nil
+}
+
+// buildMetricsForRecord returns a metrics from the query result.
+func buildMetricsForQueryResult(qr QueryResult, rule Rule) ([]metric, error) {
+	metrics := []metric{}
+
+	for _, record := range qr.Records {
+		// convert record to metrics.
+		ms, err := buildMetricsForRecord(record, rule.Name, rule.ValueCols, rule.TagCols)
+		if err != nil {
+			return metrics, err
+		}
+
+		metrics = append(metrics, ms...)
+	}
+
+	return metrics, nil
+}
+
+// buildMetricsForRecord returns a metrics from the record.
+func buildMetricsForRecord(record Record, prefix string, valueCols []string, tagCols []string) ([]metric, error) {
+	metrics := []metric{}
+
+	for _, vc := range valueCols {
+		// The value of record is a string for general purpose,
+		// so we parse and convert it to float64 here.
+		value, err := strconv.ParseFloat(record[vc], 64)
+		if err != nil {
+			return metrics, errors.Wrapf(err, "failed to ParseFloat: col = %s, type = %T(%v)", vc, record[vc], record[vc])
+		}
+
+		// build metric.
+		m := metric{
+			name:  prefix + "." + vc, // prefix is Rule.Name
+			value: value,
+			tags:  buildTags(record, tagCols),
+		}
+		metrics = append(metrics, m)
+	}
+
+	return metrics, nil
+}
+
+// buildTags returns a slice of tags from the record and column names to use for tag.
+func buildTags(record Record, tagCols []string) []string {
+	tags := []string{}
+
+	for _, tc := range tagCols {
+		// tags are formatted as column name:value.
+		tags = append(tags, tc+":"+record[tc])
+	}
+
+	return tags
 }

--- a/cyqldog/monitor.go
+++ b/cyqldog/monitor.go
@@ -29,11 +29,11 @@ func (m *Monitor) Run() error {
 	}
 
 	// Connect to the database.
-	db, err := newDB(config.Db)
+	ds, err := newDB(config.DB)
 	if err != nil {
 		return err
 	}
-	defer db.Close()
+	defer ds.Close()
 
 	// Connect to the dogstatsd.
 	statsd, err := newStatsd(config.Statd)
@@ -53,7 +53,7 @@ func (m *Monitor) Run() error {
 	// Make a monitoring worker.
 	// In order to limit the number of DB connection to 1 for monitoring,
 	// only one worker should run.
-	c := newChecker(db, statsd)
+	c := newChecker(ds, statsd)
 	go c.run(q)
 
 	// Trap signals from OS for normal termination.

--- a/cyqldog/monitor.go
+++ b/cyqldog/monitor.go
@@ -35,8 +35,8 @@ func (m *Monitor) Run() error {
 	}
 	defer ds.Close()
 
-	// Connect to the dogstatsd.
-	statsd, err := newStatsd(config.Statd)
+	// Initialize notifiers.
+	notifiers, err := newNotifiers(config.Notifiers)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (m *Monitor) Run() error {
 	// Make a monitoring worker.
 	// In order to limit the number of DB connection to 1 for monitoring,
 	// only one worker should run.
-	c := newChecker(ds, statsd)
+	c := newChecker(ds, notifiers)
 	go c.run(q)
 
 	// Trap signals from OS for normal termination.

--- a/cyqldog/notifier.go
+++ b/cyqldog/notifier.go
@@ -1,0 +1,29 @@
+package cyqldog
+
+// Notifier is an interface which send metrics to.
+type Notifier interface {
+	Put(qr QueryResult, rule Rule) error
+}
+
+// Notifiers is a map of notifiers.
+type Notifiers map[string]Notifier
+
+// NotifiersConfig are configurations of notifiers.
+type NotifiersConfig struct {
+	// Dogstatsd is a configuration of the dogstatsd to connect.
+	Dogstatsd DogstatsdConfig `yaml:"dogstatsd"`
+}
+
+// newNotifiers returns an instance of Notifiers.
+func newNotifiers(c NotifiersConfig) (Notifiers, error) {
+	notifiers := make(Notifiers)
+
+	dogstatsd, err := newDogstatsd(c.Dogstatsd)
+	if err != nil {
+		return notifiers, err
+	}
+
+	notifiers["dogstatsd"] = dogstatsd
+
+	return notifiers, nil
+}

--- a/cyqldog/rule.go
+++ b/cyqldog/rule.go
@@ -1,11 +1,6 @@
 package cyqldog
 
-import (
-	"strconv"
-	"time"
-
-	"github.com/pkg/errors"
-)
+import "time"
 
 // Rule represents monitoring conditions.
 type Rule struct {
@@ -17,73 +12,10 @@ type Rule struct {
 	Interval time.Duration `yaml:"interval"`
 	// Query to the database.
 	Query string `yaml:"query"`
+	// Notifier is a name of notifier to send metrics.
+	Notifier string `yaml:"notifier"`
 	// ValueCols is a list of names of the columns used as metric values.
 	ValueCols []string `yaml:"value_cols"`
 	// TagCols is a list of names of the columns used as metric tags.
 	TagCols []string `yaml:"tag_cols"`
-}
-
-// buildMetrics converts a row to metrics.
-func (r *Rule) buildMetrics(row []interface{}, cols []string) ([]metric, error) {
-	metrics := []metric{}
-	values := []float64{}
-	tags := []string{}
-
-	// For each column.
-	for i, c := range row {
-		// If the column is used as metric values.
-		if contains(r.ValueCols, cols[i]) {
-			switch f := c.(type) {
-			case float64:
-				values = append(values, f)
-			case int64: // integer
-				values = append(values, float64(f))
-			case []uint8:
-				// The mysql driver always returns []unit8,
-				// so we need to parse it manually.
-				f64, err := strconv.ParseFloat(string(f), 64)
-				if err != nil {
-					return metrics, errors.Wrapf(err, "failed to ParseFloat: col = %s, type = %T(%v)", cols[i], c, c)
-				}
-				values = append(values, f64)
-			default:
-				return metrics, errors.Errorf("failed to cast from interface to float64: col = %s, type = %T(%v)", cols[i], c, c)
-			}
-		}
-
-		// If the column is used as metric tags.
-		if contains(r.TagCols, cols[i]) {
-			// Tags are formatted as column name:value.
-			tag := cols[i]
-			switch s := c.(type) {
-			case string: // varchar
-				tags = append(tags, tag+":"+s)
-			case []uint8: // char (fixed-length string)
-				tags = append(tags, tag+":"+string(s))
-			default:
-				return metrics, errors.Errorf("failed to cast interface to string: col = %s, type = %T(%v)", cols[i], c, c)
-			}
-		}
-	}
-
-	// Build metrics by assigning tags for each value.
-	for i, v := range values {
-		metric := metric{
-			name:  r.Name + "." + r.ValueCols[i],
-			value: v,
-			tags:  tags,
-		}
-		metrics = append(metrics, metric)
-	}
-	return metrics, nil
-}
-
-// contains returns true if the specified string is included in the list of strings.
-func contains(s []string, key string) bool {
-	for _, e := range s {
-		if key == e {
-			return true
-		}
-	}
-	return false
 }

--- a/test-fixtures/mysql/cyqldog.yml
+++ b/test-fixtures/mysql/cyqldog.yml
@@ -7,23 +7,26 @@ data_source:
     password: {{ .DB_PASSWORD }}
     dbname: cyqldogdb
 
-dogstatsd:
-  host: {{ .DD_HOST }}
-  port: 8125
-  namespace: playground.cyqldog.mysql
-  tags:
-    - "env:local"
-    - "source:{{ .DB_HOST }}"
+notifiers:
+  dogstatsd:
+    host: {{ .DD_HOST }}
+    port: 8125
+    namespace: playground.cyqldog.mysql
+    tags:
+      - "env:local"
+      - "source:{{ .DB_HOST }}"
 
 rules:
   - name: test1
     interval: 5s
     query: "SELECT COUNT(*) AS count FROM table1"
+    notifier: dogstatsd
     value_cols:
       - count
   - name: test2
     interval: 10s
     query: "SELECT tag1, val1, tag2, val2 FROM table1"
+    notifier: dogstatsd
     tag_cols:
       - tag1
       - tag2

--- a/test-fixtures/mysql/cyqldog.yml
+++ b/test-fixtures/mysql/cyqldog.yml
@@ -1,4 +1,4 @@
-db:
+data_source:
   driver: mysql
   options:
     host: {{ .DB_HOST }}

--- a/test-fixtures/postgres/cyqldog.yml
+++ b/test-fixtures/postgres/cyqldog.yml
@@ -8,23 +8,26 @@ data_source:
     dbname: cyqldogdb
     sslmode: disable
 
-dogstatsd:
-  host: {{ .DD_HOST }}
-  port: 8125
-  namespace: playground.cyqldog.postgres
-  tags:
-    - "env:local"
-    - "source:{{ .DB_HOST }}"
+notifiers:
+  dogstatsd:
+    host: {{ .DD_HOST }}
+    port: 8125
+    namespace: playground.cyqldog.postgres
+    tags:
+      - "env:local"
+      - "source:{{ .DB_HOST }}"
 
 rules:
   - name: test1
     interval: 5s
     query: "SELECT COUNT(*) AS count FROM table1"
+    notifier: dogstatsd
     value_cols:
       - count
   - name: test2
     interval: 10s
     query: "SELECT tag1, val1, tag2, val2 FROM table1"
+    notifier: dogstatsd
     tag_cols:
       - tag1
       - tag2

--- a/test-fixtures/postgres/cyqldog.yml
+++ b/test-fixtures/postgres/cyqldog.yml
@@ -1,4 +1,4 @@
-db:
+data_source:
   driver: postgres
   options:
     host: {{ .DB_HOST }}


### PR DESCRIPTION
In order to support other providers such as Slack, now the implementations are completely overhauled and split and abstracted the interface for query data source and the interface for send metrics.