### PR TITLE
Change Docker base image to Debian.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM alpine:3.15.0
+FROM debian:bullseye-slim
 
 ENV CYQLDOG_VERSION=0.1.3
 WORKDIR /app
 RUN mkdir -p /app/bin
 
-RUN apk --no-cache add curl ca-certificates && update-ca-certificates
-RUN curl -fsSL https://github.com/crowdworks/cyqldog/releases/download/v${CYQLDOG_VERSION}/cyqldog_${CYQLDOG_VERSION}_linux_amd64.tar.gz \
-    | tar -xzC /app/bin && chmod +x /app/bin/cyqldog
-RUN apk del --purge curl
+RUN apt update && \
+    apt install -y curl ca-certificates && \
+    curl -fsSL https://github.com/crowdworks/cyqldog/releases/download/v${CYQLDOG_VERSION}/cyqldog_${CYQLDOG_VERSION}_linux_amd64.tar.gz | tar -xzC /app/bin && \
+    chmod +x /app/bin/cyqldog
 
 ENTRYPOINT ["/app/bin/cyqldog"]

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -1,10 +1,10 @@
-FROM golang:1.17-alpine AS builder
+FROM golang:1.17-bullseye AS builder
 
 WORKDIR /go/src/github.com/crowdworks/cyqldog
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/cyqldog
 
-FROM alpine:3.15.0
+FROM debian:bullseye-slim
 WORKDIR /app
 COPY --from=builder /go/src/github.com/crowdworks/cyqldog/bin/cyqldog ./bin/cyqldog
 ENTRYPOINT ["/app/bin/cyqldog"]


### PR DESCRIPTION
From Alpine 3.14, faccessat2 syscall has been enabled in musl. This requires Docker 20.10.0 or greater.
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2

You may not be able to run this container in some old environments.
So this PR change Docker base image from alpine to Debian.