### PR TITLE
Push Docker images to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: docker
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    branches:
+      - master
+      - "docker-build-*"
+    tags:
+      - "v[0-9]+.*"
+
+jobs:
+  docker:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1ZZ
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/README.md
+++ b/README.md
@@ -163,10 +163,9 @@ $ docker run -it --rm \
     psql -h docker.for.mac.localhost -U cyqldog -d cyqldogdb -f /app/config/setup_dev.sql
 ```
 
-The Docker images are available in the Docker Hub.
+The Docker images are available in the GitHub Container Registry.
 
-https://quay.io/repository/crowdworks/cyqldog?tab=tags
-
+https://github.com/crowdworks/cyqldog/pkgs/container/cyqldog
 
 Mount a sample configuration file, set environment variables, and run cyqldog.
 
@@ -176,7 +175,7 @@ $ docker run -it --rm \
     -e DB_HOST=docker.for.mac.localhost \
     -e DB_PASSWORD=password \
     -e DD_HOST=docker.for.mac.localhost \
-    quay.io/crowdworks/cyqldog:latest -C config/cyqldog.yml
+    ghcr.io/crowdworks/cyqldog:latest -C config/cyqldog.yml
 ```
 
 # Contributions

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ $ docker run -it --rm \
     -v $(pwd)/cyqldog/test-fixtures/postgres:/app/config \
     -e PGPASSWORD=password \
     postgres:alpine \
-    psql -h docker.for.mac.localhost -U cyqldog -d cyqldogdb -f /app/config/setup_dev.sql
+    psql -h host.docker.internal -U cyqldog -d cyqldogdb -f /app/config/setup_dev.sql
 ```
 
 The Docker images are available in the GitHub Container Registry.
@@ -172,9 +172,9 @@ Mount a sample configuration file, set environment variables, and run cyqldog.
 ```
 $ docker run -it --rm \
     -v $(pwd)/cyqldog/test-fixtures/postgres:/app/config \
-    -e DB_HOST=docker.for.mac.localhost \
+    -e DB_HOST=host.docker.internal \
     -e DB_PASSWORD=password \
-    -e DD_HOST=docker.for.mac.localhost \
+    -e DD_HOST=host.docker.internal \
     ghcr.io/crowdworks/cyqldog:latest -C config/cyqldog.yml
 ```
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $ docker-compose up -d
 $ docker run -it --rm \
     -v $(pwd)/cyqldog/test-fixtures/postgres:/app/config \
     -e PGPASSWORD=password \
-    postgres:alpine \
+    postgres:9.6-alpine \
     psql -h host.docker.internal -U cyqldog -d cyqldogdb -f /app/config/setup_dev.sql
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - /var/lib/mysql
 
   postgres:
-    image: postgres:alpine
+    image: postgres:9.6-alpine
     volumes_from:
       - storage-postgres
     ports:


### PR DESCRIPTION
We currently deploy our Docker images to quay.io, but we could not find a way to modify them to any tag in the automatic build.
Therefore, we will deploy the image to GitHub Container Registry.
We chose GHCR because using GitHub Actions does not require any additional credentials.

I have also included the following fixes that I found while modifying  README.

- Change internal IP address used by Docker host to `host.docker.internal`
- Pin Postgres version to 9.6 (currently, Postgres )