### PR TITLE
fix: invalid GitHub Actions login-action version

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Log in to the Container registry
-        uses: docker/login-action@v1ZZ
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
In https://github.com/crowdworks/cyqldog/pull/19, I specified invalid login-action GItHub Actions version.
(Maybe I used vim...)
So I fix it.