### PR TITLE
Update github.com/lib/pq to 1.10.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $ docker-compose up -d
 $ docker run -it --rm \
     -v $(pwd)/cyqldog/test-fixtures/postgres:/app/config \
     -e PGPASSWORD=password \
-    postgres:9.6-alpine \
+    postgres:14.1-alpine \
     psql -h host.docker.internal -U cyqldog -d cyqldogdb -f /app/config/setup_dev.sql
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - /var/lib/mysql
 
   postgres:
-    image: postgres:9.6-alpine
+    image: postgres:14.1-alpine
     volumes_from:
       - storage-postgres
     ports:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/lib/pq v0.0.0-20170707053602-dd1fe2071026
+	github.com/lib/pq v1.10.4
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/lib/pq v0.0.0-20170707053602-dd1fe2071026 h1:cibC8wCcGwIOBbP8ney1adouY90dheGj861mBFAuMQk=
-github.com/lib/pq v0.0.0-20170707053602-dd1fe2071026/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
+github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
I updated github.com/lib/pq from v0.0.0-20170707053602 to 1.10.4.
And I also updated Postgres from 9.6 to 14.1 that is used for local test.

## Test

I run cyqldog and Postgres in my local Docker environment.
Cyqldog successfully query Postgress records and send to Datadog.

```shell
$ docker-compose pull
Pulling storage-postgres ... done
Pulling storage-mysql    ... done
Pulling postgres         ... done
Pulling mysql            ... done
Pulling dogstatsd        ... done

$ docker build -t cyqldog .
[+] Building 5.7s (17/17) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                       0.0s
 => => transferring dockerfile: 37B                                                                                                                                                        0.0s
 => [internal] load .dockerignore                                                                                                                                                          0.0s
 => => transferring context: 34B                                                                                                                                                           0.0s
 => [internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                                    1.9s
 => [internal] load metadata for docker.io/library/golang:1.17.6-bullseye                                                                                                                  2.0s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                                              0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                              0.0s
 => [builder 1/6] FROM docker.io/library/golang:1.17.6-bullseye@sha256:9398cab51b551e0eb1b50a3e0478e0f9918ac892aa7d8d2341fb2cd299f4f513                                                    0.0s
 => [internal] load build context                                                                                                                                                          0.1s
 => => transferring context: 98.81kB                                                                                                                                                       0.1s
 => [stage-1 1/3] FROM docker.io/library/debian:bullseye-slim@sha256:b0d53c872fd640c2af2608ba1e693cfc7dedea30abcd8f584b23d583ec6dadc7                                                      0.0s
 => CACHED [builder 2/6] WORKDIR /go/src/github.com/crowdworks/cyqldog                                                                                                                     0.0s
 => [builder 3/6] COPY go.mod go.sum ./                                                                                                                                                    0.0s
 => [builder 4/6] RUN go mod download                                                                                                                                                      1.3s
 => [builder 5/6] COPY . .                                                                                                                                                                 0.2s
 => [builder 6/6] RUN make build                                                                                                                                                           1.9s
 => CACHED [stage-1 2/3] WORKDIR /app                                                                                                                                                      0.0s
 => [stage-1 3/3] COPY --from=builder /go/src/github.com/crowdworks/cyqldog/bin/cyqldog ./bin/cyqldog                                                                                      0.0s
 => exporting to image                                                                                                                                                                     0.1s
 => => exporting layers                                                                                                                                                                    0.1s
 => => writing image sha256:ba6b4de2ddb6f10cf255573ad1274b2d4ffcac22393ab4375f0f86061a50684f                                                                                               0.0s
 => => naming to docker.io/library/cyqldog                                                                                                                                                 0.0s

$ docker-compose up -d
Creating network "cyqldog_default" with the default driver
Creating cyqldog_storage-mysql_1    ... done
Creating cyqldog_dogstatsd_1        ... done
Creating cyqldog_storage-postgres_1 ... done
Creating cyqldog_mysql_1            ... done
Creating cyqldog_postgres_1         ... done

# create sample data
$ docker run -it --rm \
    -v $(pwd)/cyqldog/test-fixtures/postgres:/app/config \
    -e PGPASSWORD=password \
    postgres:14.1-alpine \
    psql -h host.docker.internal -U cyqldog -d cyqldogdb -f /app/config/setup_dev.sql

psql:/app/config/setup_dev.sql:4: NOTICE:  table "table1" does not exist, skipping
DROP TABLE
CREATE TABLE
INSERT 0 1
INSERT 0 1
INSERT 0 1

# run cyqldog
$ docker run -it --rm -v $(pwd)/cyqldog/test-fixtures/postgres:/app/config -e DB_HOST -e DB_PASSWORD -e DD_HOST -e DD_API_KEY cyqldog:latest -C config/cyqldog.yml
2022/01/25 04:36:23 main: starting cyqldog (version: dev, commit: none, date: unknown)
2022/01/25 04:36:23 monitor: load config file: config/cyqldog.yml
2022/01/25 04:36:23 scheduler(0): start
2022/01/25 04:36:23 scheduler(0): check on startup: test1
2022/01/25 04:36:23 scheduler(1): start
2022/01/25 04:36:23 checker: start
2022/01/25 04:36:23 scheduler(1): check on startup: test2
2022/01/25 04:36:23 checker: check: test1
2022/01/25 04:36:23 db: query: SELECT COUNT(*) AS count FROM table1
2022/01/25 04:36:23 checker: put: test1.count([]) = 3
2022/01/25 04:36:23 checker: check: test2
2022/01/25 04:36:23 db: query: SELECT tag1, val1, tag2, val2 FROM table1
2022/01/25 04:36:23 checker: put: test2.val1([tag1:hoge1    tag2:fuga1]) = 1
2022/01/25 04:36:23 checker: put: test2.val2([tag1:hoge1    tag2:fuga1]) = 0.1
2022/01/25 04:36:23 checker: put: test2.val1([tag1:hoge1    tag2:fuga2]) = 2
2022/01/25 04:36:23 checker: put: test2.val2([tag1:hoge1    tag2:fuga2]) = 0.2
2022/01/25 04:36:23 checker: put: test2.val1([tag1:hoge3    tag2:fuga3]) = 3
2022/01/25 04:36:23 checker: put: test2.val2([tag1:hoge3    tag2:fuga3]) = 0.3
2022/01/25 04:36:28 scheduler(0): triggered: test1
2022/01/25 04:36:28 checker: check: test1
2022/01/25 04:36:28 db: query: SELECT COUNT(*) AS count FROM table1
2022/01/25 04:36:28 checker: put: test1.count([]) = 3
2022/01/25 04:36:33 scheduler(0): triggered: test1
2022/01/25 04:36:33 checker: check: test1
2022/01/25 04:36:33 db: query: SELECT COUNT(*) AS count FROM table1
2022/01/25 04:36:33 scheduler(1): triggered: test2
2022/01/25 04:36:33 checker: put: test1.count([]) = 3
2022/01/25 04:36:33 checker: check: test2
2022/01/25 04:36:33 db: query: SELECT tag1, val1, tag2, val2 FROM table1
2022/01/25 04:36:33 checker: put: test2.val1([tag1:hoge1    tag2:fuga1]) = 1
2022/01/25 04:36:33 checker: put: test2.val2([tag1:hoge1    tag2:fuga1]) = 0.1
2022/01/25 04:36:33 checker: put: test2.val1([tag1:hoge1    tag2:fuga2]) = 2
2022/01/25 04:36:33 checker: put: test2.val2([tag1:hoge1    tag2:fuga2]) = 0.2
2022/01/25 04:36:33 checker: put: test2.val1([tag1:hoge3    tag2:fuga3]) = 3
2022/01/25 04:36:33 checker: put: test2.val2([tag1:hoge3    tag2:fuga3]) = 0.3
^C2022/01/25 04:36:36 monitor: stopping
2022/01/25 04:36:36 main: end
```

![image](https://user-images.githubusercontent.com/989985/150914723-e4dbba74-ebe5-466c-87c0-52f5adde9a00.png)
