### PR TITLE
add: build for linux/arm64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,6 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
+          platforms: linux/amd64, linux/arm64
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
When I pulled the image with tag 0.2.3 on the AppleSilicon machine, I got the following error.

```
kosuke.ida@CWPC20025JIS docker-cyqldog % docker compose up --build
[+] Running 2/2
 ✔ dogstatsd 1 layers [⣿]      0B/0B      Pulled                                                                                                                                     6.1s 
   ✔ ebd4bc369dd8 Pull complete                                                                                                                                                      2.4s 
[+] Building 2.0s (3/3) FINISHED                                                                                                                                     docker:desktop-linux
 => [cyqldog internal] load .dockerignore                                                                                                                                            0.0s
 => => transferring context: 84B                                                                                                                                                     0.0s
 => [cyqldog internal] load build definition from Dockerfile                                                                                                                         0.0s
 => => transferring dockerfile: 604B                                                                                                                                                 0.0s
 => ERROR [cyqldog internal] load metadata for ghcr.io/crowdworks/cyqldog:0.2.3                                                                                                      1.9s
------
 > [cyqldog internal] load metadata for ghcr.io/crowdworks/cyqldog:0.2.3:
------
failed to solve: ghcr.io/crowdworks/cyqldog:0.2.3: no match for platform in manifest sha256:21e44cd296e563156c9a8bf37a806686c952446f3df54dfd386ace24d4f89bcb: not found
kosuke.ida@CWPC20025JIS docker-cyqldog % docker pull ghcr.io/crowdworks/cyqldog:0.2.3
0.2.3: Pulling from crowdworks/cyqldog
no matching manifest for linux/arm64/v8 in the manifest list entries
```

so I added support for the linux/arm64 image in this PR.