### PR TITLE
Update Go version in Dockerfile to 1.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.3-bookworm AS builder
+FROM golang:1.24.1-bookworm AS builder
 
 WORKDIR /go/src/github.com/crowdworks/cyqldog
 


### PR DESCRIPTION
Update Go version in Dockerfile to 1.24.1.
https://hub.docker.com/_/golang