### PR TITLE
docs: remove circleci badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # cyqldog
-[![CircleCI](https://circleci.com/gh/crowdworks/cyqldog.svg?style=svg)](https://circleci.com/gh/crowdworks/cyqldog)
 [![GitHub release](http://img.shields.io/github/release/crowdworks/cyqldog.svg?style=flat-square)](https://github.com/crowdworks/cyqldog/releases)
 [![GoDoc](https://godoc.org/github.com/crowdworks/cyqldog/cyqldog?status.svg)](https://godoc.org/github.com/crowdworks/cyqldog/cyqldog)
 


### PR DESCRIPTION
Already changed test workflow from CircleCI to GitHub Actions by https://github.com/crowdworks/cyqldog/pull/15